### PR TITLE
Questions about this plugin.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,13 +14,17 @@ PATH
   remote: .
   specs:
     vagrant-serverspec (0.0.1)
+      ci_reporter (~> 1.9.0)
       serverspec (~> 0.12.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    builder (3.2.2)
     childprocess (0.3.9)
       ffi (~> 1.0, >= 1.0.11)
+    ci_reporter (1.9.0)
+      builder (>= 2.1.2)
     diff-lcs (1.2.5)
     erubis (2.7.0)
     ffi (1.9.3)
@@ -44,7 +48,7 @@ GEM
       net-ssh
       rspec (>= 2.13.0)
       specinfra (>= 0.0.2)
-    specinfra (0.0.4)
+    specinfra (0.0.9)
 
 PLATFORMS
   ruby

--- a/lib/vagrant-serverspec/command.rb
+++ b/lib/vagrant-serverspec/command.rb
@@ -1,0 +1,57 @@
+
+module VagrantPlugins
+  module ServerSpec
+    class Command < Vagrant.plugin('2', :command)
+
+      def execute
+        opts = OptionParser.new do |o|
+          o.banner = 'Usage: vagrant serverspec [vm-name]'
+        end
+
+        vms = parse_options(opts)
+        return unless vms
+
+        @logger.debug "'serverspec' each target VM..."
+        with_target_vms(vms) {|vm| run_on(vm) }
+      end
+
+      def run_on(vm)
+        raise Vagrant::Errors::VMNotCreatedError if vm.state.id == :not_created
+        raise Vagrant::Errors::VMInaccessible    if vm.state.id == :inaccessible
+        raise Vagrant::Errors::VMNotRunningError if vm.state.id != :running
+
+        vm.env.ui.info "[#{vm.name}] Running rspec..."
+
+        spec_files = vm.config.serverspec.spec_files
+        # if spec_files not specified, fallback to auto detection based on vm name.
+        if spec_files.empty?
+          # TODO should we have base_dir option? e.g "#{base_dir}/#{vm.name}/**/*_spec.rb"
+          pattern = "**/#{vm.name.to_sym}/**/*_spec.rb"
+          spec_files = Dir[pattern]
+          vm.env.ui.info "[#{vm.name}] No spec pattern specified, use `#{pattern}` instead."
+        end
+
+        ::RSpec.configure do |spec|
+          spec.exclusion_filter = vm.config.serverspec.exclusion_filter
+
+          spec.before :all do
+            ssh_host                 = vm.ssh_info[:host]
+            ssh_username             = vm.ssh_info[:username]
+            ssh_opts                 = Net::SSH::Config.for(vm.ssh_info[:host])
+            ssh_opts[:port]          = vm.ssh_info[:port]
+            ssh_opts[:forward_agent] = vm.ssh_info[:forward_agent]
+            ssh_opts[:keys]          = vm.ssh_info[:private_key_path]
+
+            spec.ssh = Net::SSH.start(ssh_host, ssh_username, ssh_opts)
+          end
+
+          spec.after :all do
+            spec.ssh.close if spec.ssh && !spec.ssh.closed?
+          end
+        end
+
+        ::RSpec::Core::Runner.run(spec_files)
+      end
+    end
+  end
+end

--- a/lib/vagrant-serverspec/command.rb
+++ b/lib/vagrant-serverspec/command.rb
@@ -1,26 +1,62 @@
+require 'rspec'
 
 module VagrantPlugins
   module ServerSpec
     class Command < Vagrant.plugin('2', :command)
 
       def execute
+        options = {}
+        options[:provision_enabled] = true
+        options[:destroy_enabled]   = true
+        options[:ci_report]         = false
+
         opts = OptionParser.new do |o|
-          o.banner = 'Usage: vagrant serverspec [vm-name]'
+          o.banner = 'Usage: vagrant serverspec [vm-name] [options] [-h]'
+          o.separator ''
+
+          o.on('--[no-]provision', 'Enable or disable provisioning before the spec runs.') do |provision|
+            options[:provision_enabled] = provision
+          end
+
+          o.on('--[no-]destroy', 'Enable or disable destroy after the spec runs.') do |destroy|
+            options[:destroy_enabled] = destroy
+          end
+
+          o.on('--ci-report', 'Enable CI Report.') do |ci_report|
+            options[:ci_report_enabled] = ci_report
+          end
+
         end
 
         vms = parse_options(opts)
         return unless vms
 
         @logger.debug "'serverspec' each target VM..."
-        with_target_vms(vms) {|vm| run_on(vm) }
+        with_target_vms(vms) do |vm|
+          vm.env.cli('up', vm.name) unless vm.state.id == :running
+          vm.env.cli('provision', vm.name) if options[:provision_enabled]
+
+          vm.env.ui.info "[#{vm.name}] Running rspec..."
+
+          begin
+            run_on(vm, options)
+          rescue => e
+            vm.env.ui.warn "[#{vm.name}] spec failed: #{[e.message, e.backtrace].flatten.join("\n")}"
+          ensure
+            if options[:destroy_enabled]
+              vm.env.cli('destroy', '--force', vm.name)
+            else
+              vm.env.cli('halt', vm.name)
+            end
+          end
+          vm.env.ui.info "[#{vm.name}] rspec done."
+        end
       end
 
-      def run_on(vm)
+      def run_on(vm, options)
         raise Vagrant::Errors::VMNotCreatedError if vm.state.id == :not_created
         raise Vagrant::Errors::VMInaccessible    if vm.state.id == :inaccessible
         raise Vagrant::Errors::VMNotRunningError if vm.state.id != :running
-
-        vm.env.ui.info "[#{vm.name}] Running rspec..."
 
         spec_files = vm.config.serverspec.spec_files
         # if spec_files not specified, fallback to auto detection based on vm name.
@@ -32,7 +68,14 @@ module VagrantPlugins
         end
 
         ::RSpec.configure do |spec|
-          spec.exclusion_filter = vm.config.serverspec.exclusion_filter
+          if spec.exclusion_filter = vm.config.serverspec.exclusion_filter
+            vm.env.ui.info "[#{vm.name}] Set exclusion filter: #{spec.exclusion_filter.inspect}."
+          end
+          if options[:ci_report_enabled]
+            require 'ci/reporter/rspec'
+            spec.formatter = CI::Reporter::RSpec
+            vm.env.ui.info "[#{vm.name}] Use ci_report formatter."
+          end
 
           spec.before :all do
             ssh_host                 = vm.ssh_info[:host]
@@ -52,6 +95,7 @@ module VagrantPlugins
 
         ::RSpec::Core::Runner.run(spec_files)
       end
+
     end
   end
 end

--- a/lib/vagrant-serverspec/config.rb
+++ b/lib/vagrant-serverspec/config.rb
@@ -1,35 +1,41 @@
 module VagrantPlugins
   module ServerSpec
     class Config < Vagrant.plugin('2', :config)
-      attr_accessor :spec_files
+      attr_accessor :spec_files, :exclusion_filter
 
       def initialize
         super
-        @spec_files = UNSET_VALUE
+        @spec_files        = UNSET_VALUE
+        @exclusioin_filter = UNSET_VALUE
       end
 
-      def pattern=(pat)
-        @spec_files = Dir.glob(pat)
+      def pattern=(pattern)
+        @spec_files = Dir.glob(pattern)
+      end
+
+      def excludes=(excludes)
+        @exclusion_filter = excludes.reduce({}) {|mem, ex| mem[ex.to_sym] = true; mem }
       end
 
       def finalize!
-        @spec_files = [] if @spec_files == UNSET_VALUE
+        @spec_files       = []  if @spec_files       == UNSET_VALUE
+        @exclusion_filter = nil if @exclusion_filter == UNSET_VALUE
       end
 
       def validate(machine)
         errors = _detected_errors
 
-        if @spec_files.nil? || @spec_files.empty?
-          errors << I18n.t('vagrant.config.serverspec.no_spec_files')
+        unless (@spec_files.nil? || @spec_files.empty?)
+          missing_files = @spec_files.select { |path| !File.file?(path) }
+          unless missing_files.empty?
+            errors << I18n.t('vagrant.config.serverspec.missing_spec_files', files: missing_files.join(', '))
+          end
         end
 
-        missing_files = @spec_files.select { |path| !File.file?(path) }
-        unless missing_files.empty?
-          errors << I18n.t('vagrant.config.serverspec.missing_spec_files', files: missing_files.join(', '))
-        end
-
-        { 'serverspec provisioner' => errors }
+        { 'serverspec command' => errors }
       end
+
     end
+
   end
 end

--- a/lib/vagrant-serverspec/plugin.rb
+++ b/lib/vagrant-serverspec/plugin.rb
@@ -6,14 +6,14 @@ module VagrantPlugins
       This plugin executes a serverspec suite against a running Vagrant instance.
       DESC
 
-      config(:serverspec, :provisioner) do
+      config(:serverspec) do
         require_relative 'config'
         Config
       end
 
-      provisioner(:serverspec) do
-        require_relative 'provisioner'
-        Provisioner
+      command(:serverspec) do
+        require_relative 'command'
+        Command
       end
     end
   end

--- a/vagrant-serverspec.gemspec
+++ b/vagrant-serverspec.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_dependency 'serverspec', '~> 0.12.0'
+  gem.add_dependency 'ci_reporter', '~> 1.9.0'
 
   gem.add_development_dependency 'bundler', '~> 1.3'
   gem.add_development_dependency 'rake'


### PR DESCRIPTION
Hi, this is really nice plugin, but I have some questions/feature requests as following:

#### Isn't it better to use command instead of provisioner?

In my opinion, a provisioner should provision something to vagrant instances, so how about to use command instead of provisioner? 

#### Multi vm support

Any plans to support multi vm environment? like as this [gist](https://gist.github.com/riywo/5579491)

#### Spec exclusion support

In case of sharing specs both vagrant and actual server(see following), it is better to have exclusion feature.

```ruby
describe "my-host" do
  it "should be pass both vagrant and production" do
    # brabrabra
  end 
  it "should be pass only production", :production => true do
    # Of cource, we need different way to execute this example like as executing `rake acceptance`  or etc..
  end
end
```

If you have plan or agree these features, I am glad to contribute:)