### PR TITLE
Change README to use 'vagrant plugin' for install

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,15 @@ Issues and pull requests are welcome.
 
 ## Example Usage
 
-First, you'll need to load the plugin and configure the provisioner.
+First, install the plugin.
+
+```shell
+$ vagrant plugin install vagrant-serverspec
+```
+
+Next, configure the provisioner in your `Vagrantfile`.
 
 ```ruby
-Vagrant.require_plugin('vagrant-serverspec')
-
 Vagrant.configure('2') do |config|
   config.vm.box = 'precise64'
   config.vm.box_url = 'http://cloud-images.ubuntu.com/precise/current/precise-server-cloudimg-vagrant-amd64-disk1.box'


### PR DESCRIPTION
`Vagrant.require_plugin` seems to be deprecated - with Vagrant 1.6.5, on `vagrant up` I get the message:

```
Vagrant.require_plugin is deprecated and has no effect any longer.
Use `vagrant plugin` commands to manage plugins. This warning will
be removed in the next version of Vagrant.
```