### PR TITLE
added support for WinRM communication

### DIFF
--- a/WINDOWS_SUPPORT.md
+++ b/WINDOWS_SUPPORT.md
@@ -1,0 +1,58 @@
+# vagrant-serverspec Windows support
+
+vagrant-serverspec is a [vagrant](http://vagrantup.com) plugin that implements
+[serverspec](http://serverspec.org) as a provisioner.
+It also supports Windows guests through WinRM.
+
+## Example Usage
+
+First, you'll need to install the plugin.
+
+```shell
+vagrant plugin install vagrant-serverspec
+```
+
+Then create a Windows box.
+
+```ruby
+Vagrant.configure('2') do |config|
+  config.vm.box = 'ferventcoder/win7pro-x64-nocm-lite'
+
+  config.vm.provision :serverspec do |spec|
+    spec.pattern = '*_spec.rb'
+  end
+end
+```
+
+You'll want to place some boilerplate into a file named `spec_helper.rb`
+
+```ruby
+require 'serverspec'
+require 'pathname'
+require 'winrm'
+
+include Serverspec::Helper::WinRM
+include Serverspec::Helper::Windows
+```
+
+Then you're ready to write your specs.
+
+```ruby
+require_relative 'spec_helper'
+
+describe user('vagrant') do
+  it { should exist }
+  it { should belong_to_group('Administrators')}
+end
+
+describe port(5985) do
+  it { should be_listening }
+end
+
+describe file('c:/windows') do
+  it { should be_directory }
+  it { should_not be_writable.by('Everyone') }
+end
+```
+
+See more details at [serverspec WINDOWS_SUPPORT.md](https://github.com/serverspec/serverspec/blob/093cd1a0ca61325e1d54578118f8b30523aae2c1/WINDOWS_SUPPORT.md).

--- a/lib/vagrant-serverspec/provisioner.rb
+++ b/lib/vagrant-serverspec/provisioner.rb
@@ -11,25 +11,43 @@ module VagrantPlugins
 
         @spec_files = config.spec_files
 
-        RSpec.configure do |spec|
-          spec.before :all do
-            ssh_host                 = machine.ssh_info[:host]
-            ssh_username             = machine.ssh_info[:username]
-            ssh_opts                 = Net::SSH::Config.for(machine.ssh_info[:host])
-            ssh_opts[:port]          = machine.ssh_info[:port]
-            ssh_opts[:forward_agent] = machine.ssh_info[:forward_agent]
-            ssh_opts[:keys]          = machine.ssh_info[:private_key_path]
+        unless machine.config.vm.communicator == :winrm
+          # SSH
+          RSpec.configure do |spec|
+            spec.before :all do
+              ssh_host                 = machine.ssh_info[:host]
+              ssh_username             = machine.ssh_info[:username]
+              ssh_opts                 = Net::SSH::Config.for(machine.ssh_info[:host])
+              ssh_opts[:port]          = machine.ssh_info[:port]
+              ssh_opts[:forward_agent] = machine.ssh_info[:forward_agent]
+              ssh_opts[:keys]          = machine.ssh_info[:private_key_path]
 
-            spec.ssh = Net::SSH.start(ssh_host, ssh_username, ssh_opts)
-          end
+              spec.ssh = Net::SSH.start(ssh_host, ssh_username, ssh_opts)
+            end
 
-          spec.after :all do
-            spec.ssh.close if spec.ssh && !spec.ssh.closed?
+            spec.after :all do
+              spec.ssh.close if spec.ssh && !spec.ssh.closed?
+            end
           end
         end
       end
 
       def provision
+        if machine.config.vm.communicator == :winrm
+          # WinRM
+          username = machine.config.winrm.username
+          winrm_info = VagrantPlugins::CommunicatorWinRM::Helper.winrm_info(@machine)
+
+          RSpec.configure do |c|
+            user = machine.config.winrm.username
+            pass = machine.config.winrm.password
+            endpoint = "http://#{winrm_info[:host]}:#{winrm_info[:port]}/wsman"
+
+            c.winrm = ::WinRM::WinRMWebService.new(endpoint, :ssl, :user => user, :pass => pass, :basic_auth_only => true)
+            c.winrm.set_timeout machine.config.winrm.timeout
+          end
+        end
+
         RSpec::Core::Runner.run(@spec_files)
       end
     end


### PR DESCRIPTION
I have added WinRM support to use vagrant-serverspec for Windows guests through Vagrant 1.6+ new communicator.
There is a sample in the `WINDOWS_SUPPORT.md` file that shows the differences in the `spec_helper.rb` file.
I'll try to keep this PR in sync with #10, but I have started from your master branch.
