### PR TITLE
add OSX docker support

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ describe port(22) do
 end
 ```
 
+##Testing Docker Containers on OSX
+On OSX the Vagrant docker provider runs a Boot2Docker VM, then launches your docker container on that VM. Vagrant does SSH Proxying to send the commands through that VM and have them reach the Docker Container. Vagrant serverspec handles this the same way by getting the container host VM infromation and proxying the commands to the machine through an SSH Proxy. This functionality was introduced in this [PR](https://github.com/jvoorhis/vagrant-serverspec/pull/17) 
+
 ## Versioning
 
 Test Kitchen aims to adhere to [Semantic Versioning 2.0.0][semver].

--- a/lib/vagrant-serverspec/plugin.rb
+++ b/lib/vagrant-serverspec/plugin.rb
@@ -3,7 +3,8 @@ require 'serverspec'
 require 'pathname'
 require 'winrm'
 require 'net/ssh'
-
+require 'net/ssh/proxy/command'
+require 'os'
  module VagrantPlugins
   module ServerSpec
     class Plugin < Vagrant.plugin('2')

--- a/lib/vagrant-serverspec/version.rb
+++ b/lib/vagrant-serverspec/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module ServerSpec
-    VERSION = '1.0.1'
+    VERSION = '1.0.2'
   end
 end

--- a/test/Docker/.rspec
+++ b/test/Docker/.rspec
@@ -1,0 +1,2 @@
+--color
+--format documentation

--- a/test/Docker/Docker_Vagrantfile
+++ b/test/Docker/Docker_Vagrantfile
@@ -1,0 +1,13 @@
+Vagrant.configure("2") do |config|
+  config.vm.box = "mitchellh/boot2docker"
+
+  config.vm.provider "virtualbox" do |v|
+    # On VirtualBox, we don't have guest additions or a functional vboxsf
+    # in TinyCore Linux, so tell Vagrant that so it can be smarter.
+    v.check_guest_additions = false
+    v.functional_vboxsf     = false
+    v.customize ["modifyvm", :id, "--memory", "1024"]
+  end
+
+  config.nfs.functional = false
+end

--- a/test/Docker/Vagrantfile
+++ b/test/Docker/Vagrantfile
@@ -1,0 +1,17 @@
+Vagrant.configure('2') do |config|
+  config.vm.provider "docker" do |d|
+    d.vagrant_vagrantfile = "./Docker_Vagrantfile"
+    d.image = "jjhughes57/docker-vagrant-ubuntu"
+    d.has_ssh = true
+  end
+
+  config.vm.provision :shell, inline: <<-EOF
+    sudo apt-get install -y vim
+    touch /tmp/testfile
+  EOF
+
+  config.vm.provision :serverspec do |spec|
+    spec.pattern = '*_spec.rb'
+    #Specinfra.configuration.sudo_password = 'vagrant'
+  end
+end

--- a/test/Docker/sample_spec.rb
+++ b/test/Docker/sample_spec.rb
@@ -1,0 +1,9 @@
+require_relative 'spec_helper'
+
+describe package('vim') do
+  it { should be_installed }
+end
+
+describe file('/tmp/testfile') do
+  it { should be_file }
+end

--- a/test/Docker/spec_helper.rb
+++ b/test/Docker/spec_helper.rb
@@ -1,0 +1,13 @@
+#require 'serverspec'
+#require 'net/ssh'
+
+#set :backend, :ssh
+
+# Disable sudo
+# set :disable_sudo, true
+
+# Set environment variables
+# set :env, :LANG => 'C', :LC_MESSAGES => 'C' 
+
+# Set PATH
+# set :path, '/sbin:/usr/local/sbin:$PATH'

--- a/vagrant-serverspec.gemspec
+++ b/vagrant-serverspec.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency 'serverspec', '~> 2.7', '>= 2.7.0'
   gem.add_runtime_dependency 'winrm', '~> 1.1', '>= 1.1.0'
+  gem.add_runtime_dependency 'os', '~> 0.9.6'
   #gem.add_runtime_dependency 'highline', '~> 1.6', '>= 1.6.20'
 
   gem.add_development_dependency 'bundler', '~> 1.6', '>= 1.6.2'


### PR DESCRIPTION
This resolves #16 

In the case when executing serverspec on OSX vagrant-serverspec will now proxy ssh commands through the boot2docker host vagrant creates to the container. It only does this on OSX so linux functionality where docker is running on the same machine as vagrant should be unaffected. 

 