### PR TITLE
provide compatibility with vagrant 1.9.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+### Supported Release - 1.2.0
+***
+
+* Updated .gemspec to the recommended winrm version 2.x
+* Updated WinRM::Connection instead of WinRM::WebService

--- a/lib/vagrant-serverspec/provisioner.rb
+++ b/lib/vagrant-serverspec/provisioner.rb
@@ -15,12 +15,15 @@ module VagrantPlugins
           winrm_info = VagrantPlugins::CommunicatorWinRM::Helper.winrm_info(@machine)
           set :backend, :winrm
           set :os, :family => 'windows'
-          user = machine.config.winrm.username
-          pass = machine.config.winrm.password
-          endpoint = "http://#{winrm_info[:host]}:#{winrm_info[:port]}/wsman"
 
-          winrm = ::WinRM::WinRMWebService.new(endpoint, :ssl, :user => user, :pass => pass, :basic_auth_only => true)
-          winrm.set_timeout machine.config.winrm.timeout
+          opts = {
+              endpoint: "http://#{winrm_info[:host]}:#{winrm_info[:port]}/wsman",
+              user: machine.config.winrm.username,
+              password: machine.config.winrm.password,
+              transport: :ssl,
+              operation_timeout: machine.config.winrm.timeout
+          }
+          winrm = ::WinRM::Connection.new(opts)
           Specinfra.configuration.winrm = winrm
         else
           set :backend, :ssh
@@ -101,3 +104,4 @@ module VagrantPlugins
     end
   end
 end
+

--- a/lib/vagrant-serverspec/version.rb
+++ b/lib/vagrant-serverspec/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module ServerSpec
-    VERSION = '1.1.1'
+    VERSION = '1.2'
   end
 end

--- a/vagrant-serverspec.gemspec
+++ b/vagrant-serverspec.gemspec
@@ -16,11 +16,12 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_runtime_dependency 'serverspec', '~> 2.7', '>= 2.7.0'
-  gem.add_runtime_dependency 'winrm', '~> 1.1', '>= 1.1.0'
+  gem.add_runtime_dependency 'serverspec', '~> 2.30', '>= 2.30'
+  
+  #add onlly dependencies for winrm without nokogiri
+  gem.add_runtime_dependency 'winrm', '~> 2.1', '>= 2.1'
   gem.add_runtime_dependency 'os', '~> 0.9.6'
-  #gem.add_runtime_dependency 'highline', '~> 1.6', '>= 1.6.20'
-
+  
   gem.add_development_dependency 'bundler', '~> 1.6', '>= 1.6.2'
   gem.add_development_dependency 'rake', '~> 10.3', '>= 10.3.2'
 end


### PR DESCRIPTION
* Vagrant provided `winrm 2.1.2` as of `1.9.2` and the new WinRM gem exposes a new way of connecting to WinRM https://github.com/WinRb/WinRM#connection-options